### PR TITLE
Add dependencies inside docker dinamically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 bundles/
 *.test
 profile.cov
+/site
+/hack/deps.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,10 @@ RUN go get golang.org/x/tools/cmd/cover && \
     go get golang.org/x/tools/cmd/godoc && \
     go get golang.org/x/tools/cmd/vet
 
+ENV STORAGE_ENGINE leveldb
+
+ADD hack/deps.txt /deps.txt
+ADD hack/deps.sh /deps.sh
+RUN /deps.sh
+
 WORKDIR /go/src/github.com/NeowayLabs/neosearch

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,10 @@ docs-view: docs
 docs-shell: build-docs
 	docker run --rm $(MOUNT_DEV_VOLUME) --privileged -t -i $(DOCKER_DOCSIMAGE) bash
 
-build:
+hack/deps.txt:
+	./hack/gendeps.sh "$(STORAGE_ENGINE)"
+
+build: hack/deps.txt
 	docker build -t $(DOCKER_DEVIMAGE) .
 
 build-docs: build

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -23,13 +23,11 @@ test -z "$(golint .          | tee /dev/stderr)"
 
 echo "mode: count" > profile.cov
 
-$GO get -tags "$STORAGE_ENGINE" ./...
-
 # Standard $GO tooling behavior is to ignore dirs with leading underscors
 for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path './Godeps/*' -type d);
 do
     if ls $dir/*.go &> /dev/null; then
-	$GO test $TEST_FLAGS -covermode=count -coverprofile="$dir/profile.tmp" "$dir"
+	$GO test $TEST_FLAGS -v -race -covermode=count -coverprofile="$dir/profile.tmp" "$dir"
 	if [ -f $dir/profile.tmp ]
 	then
             cat $dir/profile.tmp | tail -n +2 >> profile.cov

--- a/hack/deps.sh
+++ b/hack/deps.sh
@@ -1,3 +1,11 @@
 #!/usr/bin/env bash
 
-go get -tags leveldb ./...
+DEPS_FILE="$1"
+
+if [[ -z "$DEPS_FILE" ]]; then
+    DEPS_FILE="/deps.txt"
+fi
+
+cat "$DEPS_FILE" | xargs go get -tags $STORAGE_ENGINE -v -d 2>/dev/null
+
+exit 0

--- a/hack/gendeps.sh
+++ b/hack/gendeps.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+STORAGE_ENGINE="$1"
+
+if [[ -z "$STORAGE_ENGINE" ]]; then
+   STORAGE_ENGINE="leveldb"
+fi
+
+echo "Generating dependencies file for storage engine ($STORAGE_ENGINE): hack/deps.txt"
+go get -v -u -tags "$STORAGE_ENGINE" ./... 2>&1 | grep download | grep -v neosearch | sed 's/ (download)//g' > hack/deps.txt
+


### PR DESCRIPTION
My problem:
- I don't want to have the go dependencies hardcode inside the Dockerfile;
- I don't want to execute "go get -d ./..." in every "make check" because it slows down the code-test flow.

Solution:

I create a new script hack/gendeps.sh executed by Makefile that generates a file hack/deps.txt when it do not exists and added hack/deps.sh inside the dev docker. The hack/deps.sh works for Dockerfile or to solve dependencies manually in the host.

This approach doesn't seem good but solves my current problem.

@katcipis Could you test if this PR works in your env?

What's the best way to achieve that?
