### PR TITLE
Refactory on the store package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: go
 go:
   - 1.3
   - tip
-install: 
+install:
   - cd /tmp && git clone https://github.com/google/leveldb.git && cd /tmp/leveldb && make
   - cd $HOME/gopath/src/github.com/NeowayLabs/neosearch
   - go get -v github.com/jmhodges/levigo
-  - go get -d -v ./...
+  - go get -tags leveldb -d -v ./...
   - go build -tags leveldb -v ./...
 script:
   - go get golang.org/x/tools/cmd/vet
@@ -26,6 +26,7 @@ notifications:
   email:
     - tiago.natel@neoway.com.br
     - tiagokatcipis@gmail.com
+    - paulo.pizarro@gmail.com
   webhooks:
     urls:
       - "https://webhooks.gitter.im/e/5c49f66645e9c101199e"

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -54,9 +54,9 @@ func main() {
 	}
 
 	ng := engine.New(engine.NGConfig{
-		KVCfg: &store.KVConfig{
-			DataDir: dataDirOpt,
-			Debug:   debugOpt,
+		KVCfg: store.KVConfig{
+			"dataDir": dataDirOpt,
+			"debug":   debugOpt,
 		},
 	})
 

--- a/cmd/import/main.go
+++ b/cmd/import/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/index"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/store"
 	"github.com/jteeuwen/go-pkg-optarg"
 )
 
@@ -102,7 +103,10 @@ func main() {
 
 	cfg.Option(neosearch.DataDir(dataDirOpt))
 	cfg.Option(neosearch.Debug(debugOpt))
-	cfg.Option(neosearch.KVCacheSize(1 << 15))
+	cfg.Option(neosearch.KVConfig(store.KVConfig{
+		"enableCache": true,
+		"cacheSize":   (1 << 15),
+	}))
 
 	neo := neosearch.New(cfg)
 

--- a/lib/neosearch/config.go
+++ b/lib/neosearch/config.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/NeowayLabs/neosearch/lib/neosearch/store"
 	"gopkg.in/yaml.v2"
 )
 
@@ -23,15 +24,11 @@ type Config struct {
 	// Enables debug in every sub-module
 	Debug bool `yaml:"debug"`
 
-	// CacheSize is the length of LRU cache used by the storage engine
-	// Default is 1GB
-	KVCacheSize int `yaml:"cacheSize"`
-
 	// IndicesCacheSize is the max number of indices maintained open
 	MaxIndicesOpen int `yaml:"maxIndicesOpen"`
 
-	// EnableCache enable/disable cache support
-	EnableCache bool `yaml:"enableCache"`
+	// Specific options to store
+	KVConfig store.KVConfig `yaml:"store"`
 }
 
 // NewConfig creates new config
@@ -44,7 +41,6 @@ func (c *Config) Option(opts ...Option) (previous Option) {
 	for _, opt := range opts {
 		previous = opt(c)
 	}
-
 	return previous
 }
 
@@ -53,18 +49,7 @@ func Debug(t bool) Option {
 	return func(c *Config) Option {
 		previous := c.Debug
 		c.Debug = t
-
 		return Debug(previous)
-	}
-}
-
-// EnableCache enables or disable index cache
-func EnableCache(t bool) Option {
-	return func(c *Config) Option {
-		previous := c.EnableCache
-		c.EnableCache = t
-
-		return EnableCache(previous)
 	}
 }
 
@@ -73,22 +58,7 @@ func DataDir(path string) Option {
 	return func(c *Config) Option {
 		previous := c.DataDir
 		c.DataDir = path
-
 		return DataDir(previous)
-	}
-}
-
-// KVCacheSize set the size of the cache for the LRU storage cache.
-// The link below have more details on the cache mechanism of the
-// leveldb (or any other LSM compatible):
-// More details in the section "Performance" of the link below:
-// http://htmlpreview.github.io/?https://github.com/google/leveldb/blob/master/doc/index.html
-func KVCacheSize(size int) Option {
-	return func(c *Config) Option {
-		previous := c.KVCacheSize
-		c.KVCacheSize = size
-
-		return KVCacheSize(previous)
 	}
 }
 
@@ -97,8 +67,16 @@ func MaxIndicesOpen(size int) Option {
 	return func(c *Config) Option {
 		previous := c.MaxIndicesOpen
 		c.MaxIndicesOpen = size
-
 		return MaxIndicesOpen(previous)
+	}
+}
+
+// Specific configurations to store
+func KVConfig(kvconfig store.KVConfig) Option {
+	return func(c *Config) Option {
+		previous := c.KVConfig
+		c.KVConfig = kvconfig
+		return KVConfig(previous)
 	}
 }
 

--- a/lib/neosearch/engine/engine.go
+++ b/lib/neosearch/engine/engine.go
@@ -95,8 +95,12 @@ func (ng *Engine) open(indexName, databaseName string) (store.KVStore, error) {
 	value, ok = ng.stores.Get(indexName + "." + databaseName)
 
 	if ok == false || value == nil {
-		storekv, err = store.New(ng.config.KVCfg)
+		storeConstructor := store.KVStoreConstructorByName("leveldb")
+		if storeConstructor == nil {
+			return nil, errors.New("Unknown storage type")
+		}
 
+		storekv, err = storeConstructor(ng.config.KVCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/neosearch/engine/engine.go
+++ b/lib/neosearch/engine/engine.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch/cache"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/store"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/store/leveldb"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/utils"
 )
 
 const (
+	DefaultKVStore = leveldb.KVName
+
 	// OpenCacheSize is the default value for the maximum number of
 	// open database files. This value can be override by
 	// NGConfig.OpenCacheSize.
@@ -95,7 +98,7 @@ func (ng *Engine) open(indexName, databaseName string) (store.KVStore, error) {
 	value, ok = ng.stores.Get(indexName + "." + databaseName)
 
 	if ok == false || value == nil {
-		storeConstructor := store.KVStoreConstructorByName("leveldb")
+		storeConstructor := store.KVStoreConstructorByName(DefaultKVStore)
 		if storeConstructor == nil {
 			return nil, errors.New("Unknown storage type")
 		}

--- a/lib/neosearch/engine/engine_test.go
+++ b/lib/neosearch/engine/engine_test.go
@@ -67,8 +67,8 @@ func cmpIterator(t *testing.T, itReturns []map[int64]string, ng *Engine, seek []
 // a LSM database ordered by key with ByteWise comparator.
 func TestEngineIntegerKeyOrder(t *testing.T) {
 	ng := New(NGConfig{
-		KVCfg: &store.KVConfig{
-			DataDir: DataDirTmp,
+		KVCfg: store.KVConfig{
+			"dataDir": DataDirTmp,
 		},
 		OpenCacheSize: 1,
 	})

--- a/lib/neosearch/index.go
+++ b/lib/neosearch/index.go
@@ -125,10 +125,6 @@ func New(cfg *Config) *NeoSearch {
 		cfg.DataDir = cfg.DataDir[0 : len(cfg.DataDir)-1]
 	}
 
-	if cfg.KVCacheSize == 0 && cfg.EnableCache {
-		cfg.KVCacheSize = 3 << 30
-	}
-
 	if cfg.MaxIndicesOpen == 0 {
 		cfg.MaxIndicesOpen = maxIndicesOpen
 	}
@@ -159,10 +155,9 @@ func (neo *NeoSearch) CreateIndex(name string) (*index.Index, error) {
 	indx, err := index.New(
 		name,
 		index.Config{
-			DataDir:     neo.config.DataDir,
-			Debug:       neo.config.Debug,
-			CacheSize:   neo.config.KVCacheSize,
-			EnableCache: neo.config.EnableCache,
+			DataDir:  neo.config.DataDir,
+			Debug:    neo.config.Debug,
+			KVConfig: neo.config.KVConfig,
 		},
 		true,
 	)
@@ -223,10 +218,9 @@ func (neo *NeoSearch) OpenIndex(name string) (*index.Index, error) {
 	indx, err = index.New(
 		name,
 		index.Config{
-			DataDir:     neo.config.DataDir,
-			Debug:       neo.config.Debug,
-			CacheSize:   neo.config.KVCacheSize,
-			EnableCache: neo.config.EnableCache,
+			DataDir:  neo.config.DataDir,
+			Debug:    neo.config.Debug,
+			KVConfig: neo.config.KVConfig,
 		},
 		false,
 	)

--- a/lib/neosearch/index/index.go
+++ b/lib/neosearch/index/index.go
@@ -26,10 +26,9 @@ const (
 type Config struct {
 	// Per-Index configurations
 
-	DataDir     string
-	Debug       bool
-	CacheSize   int
-	EnableCache bool
+	DataDir  string
+	Debug    bool
+	KVConfig store.KVConfig
 }
 
 // Index represents an entire index
@@ -89,13 +88,15 @@ func (i *Index) setup(create bool) error {
 
 	i.fullDir = dataDir
 
+	kvcfg := i.config.KVConfig
+	if kvcfg == nil {
+		kvcfg = store.KVConfig{}
+	}
+	kvcfg["dataDir"] = i.config.DataDir
+	kvcfg["debug"] = i.config.Debug
+
 	i.engine = engine.New(engine.NGConfig{
-		KVCfg: &store.KVConfig{
-			DataDir:     i.config.DataDir,
-			Debug:       i.config.Debug,
-			CacheSize:   i.config.CacheSize,
-			EnableCache: i.config.EnableCache,
-		},
+		KVCfg: kvcfg,
 	})
 
 	return nil

--- a/lib/neosearch/store/leveldb/iterator.go
+++ b/lib/neosearch/store/leveldb/iterator.go
@@ -1,6 +1,6 @@
 // +build leveldb
 
-package store
+package leveldb
 
 import "github.com/jmhodges/levigo"
 

--- a/lib/neosearch/store/leveldb/reader.go
+++ b/lib/neosearch/store/leveldb/reader.go
@@ -1,8 +1,11 @@
 // +build leveldb
 
-package store
+package leveldb
 
-import "github.com/jmhodges/levigo"
+import (
+	"github.com/NeowayLabs/neosearch/lib/neosearch/store"
+	"github.com/jmhodges/levigo"
+)
 
 // LVDBReader is the readonly view of database. It implements the KVReader interface
 type LVDBReader struct {
@@ -20,7 +23,7 @@ func (reader *LVDBReader) GetCustom(opt *levigo.ReadOptions, key []byte) ([]byte
 }
 
 // GetIterator returns a new KVIterator
-func (reader *LVDBReader) GetIterator() KVIterator {
+func (reader *LVDBReader) GetIterator() store.KVIterator {
 	var ro = reader.store.readOptions
 
 	ro.SetFillCache(false)

--- a/lib/neosearch/store/leveldb/store.go
+++ b/lib/neosearch/store/leveldb/store.go
@@ -27,22 +27,7 @@ var (
 
 // Registry the leveldb module
 func init() {
-	initFn := func(config *store.KVConfig) (store.KVStore, error) {
-		if config.Debug {
-			fmt.Println("Initializing leveldb backend store")
-		}
-
-		return NewLVDB(config)
-	}
-
-	err := store.SetDefault(KVName, initFn)
-
-	if err != nil {
-		fmt.Println("Failed to initialize leveldb backend")
-	}
-
-	//onceWriter = &sync.Mutex{}
-	//onceReader = &sync.Mutex{}
+	store.RegisterKVStore(KVName, LVDBConstructor)
 }
 
 // LVDB is the leveldb interface exposed by NeoSearch

--- a/lib/neosearch/store/leveldb/store_test.go
+++ b/lib/neosearch/store/leveldb/store_test.go
@@ -1,4 +1,4 @@
-package store
+package leveldb
 
 import (
 	"io/ioutil"
@@ -6,70 +6,70 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/NeowayLabs/neosearch/lib/neosearch/store"
 )
 
 var DataDirTmp string
 
 func init() {
 	var err error
-	DataDirTmp, err = ioutil.TempDir("/tmp", "neosearch-")
+	DataDirTmp, err = ioutil.TempDir("/tmp", "neosearch-leveldb-")
 
 	if err != nil {
 		panic(err)
 	}
 }
 
-func openDatabase(t *testing.T, indexName, dbName string) KVStore {
+func openDatabase(t *testing.T, indexName, dbName string) store.KVStore {
 	var (
-		err   error
-		store KVStore
+		err     error
+		kvstore store.KVStore
 	)
 
-	cfg := KVConfig{
+	cfg := store.KVConfig{
 		DataDir: DataDirTmp,
 	}
 
-	store, err = New(&cfg)
-
+	kvstore, err = NewLVDB(&cfg)
 	if err != nil {
 		t.Error(err)
 		return nil
-	} else if store == nil {
+	} else if kvstore == nil {
 		t.Error("Failed to allocate store")
 		return nil
 	}
 
-	err = store.Open(indexName, dbName)
+	err = kvstore.Open(indexName, dbName)
 
 	if err != nil {
 		t.Error(err)
 		return nil
 	}
 
-	return store
+	return kvstore
 }
 
 func openDatabaseFail(t *testing.T, indexName, dbName string) {
 	var (
-		err   error
-		store KVStore
+		err     error
+		kvstore store.KVStore
 	)
 
-	cfg := KVConfig{
+	cfg := store.KVConfig{
 		DataDir: DataDirTmp,
 	}
 
-	store, err = New(&cfg)
-
+	kvstore, err = NewLVDB(&cfg)
 	if err != nil {
 		t.Error(err)
 		return
-	} else if store == nil {
+	} else if kvstore == nil {
 		t.Error("Failed to allocate store")
 		return
 	}
 
-	err = store.Open(indexName, dbName)
+	err = kvstore.Open(indexName, dbName)
 
 	if err == nil {
 		t.Errorf("Should fail... Invalid database name: %s", dbName)
@@ -78,18 +78,17 @@ func openDatabaseFail(t *testing.T, indexName, dbName string) {
 }
 
 func TestStoreHasBackend(t *testing.T) {
-	cfg := KVConfig{
+	cfg := store.KVConfig{
 		DataDir: DataDirTmp,
 	}
 
-	store, err := New(&cfg)
-
+	kvstore, err := NewLVDB(&cfg)
 	if err != nil {
 		t.Errorf("You need compile this package with -tags <storage-backend>: %s", err)
 		return
 	}
 
-	if store == nil {
+	if kvstore == nil {
 		t.Error("Failed to allocate KVStore")
 	}
 }
@@ -142,7 +141,7 @@ func TestOpenDatabase(t *testing.T) {
 func TestStoreSetGet(t *testing.T) {
 	var (
 		err    error
-		store  KVStore
+		store  store.KVStore
 		data   []byte
 		testDb = "test_set.db"
 	)
@@ -212,7 +211,7 @@ func TestStoreSetGet(t *testing.T) {
 func TestBatchWrite(t *testing.T) {
 	var (
 		err    error
-		store  KVStore
+		store  store.KVStore
 		key    = []byte{'a'}
 		value  = []byte{'b'}
 		data   []byte
@@ -269,7 +268,7 @@ func TestBatchWrite(t *testing.T) {
 func TestBatchMultiWrite(t *testing.T) {
 	var (
 		err    error
-		store  KVStore
+		store  store.KVStore
 		data   []byte
 		testDb = "test_set-multi.db"
 	)

--- a/lib/neosearch/store/leveldb/writer.go
+++ b/lib/neosearch/store/leveldb/writer.go
@@ -66,7 +66,7 @@ func (w *LVDBWriter) MergeSet(key []byte, value uint64) error {
 		return err
 	}
 
-	if w.store.Config.Debug {
+	if w.store.debug {
 		fmt.Printf("[INFO] %d ids == %d GB of ids\n", len(data)/8, len(data)/(1024*1024*1024))
 	}
 

--- a/lib/neosearch/store/leveldb/writer.go
+++ b/lib/neosearch/store/leveldb/writer.go
@@ -1,4 +1,6 @@
-package store
+// +build leveldb
+
+package leveldb
 
 import (
 	"bytes"

--- a/lib/neosearch/store/registry.go
+++ b/lib/neosearch/store/registry.go
@@ -1,0 +1,29 @@
+package store
+
+import "errors"
+
+// KVFuncConstructor is the register function that every store backend need to implement.
+type KVFuncConstructor func(*KVConfig) (KVStore, error)
+
+// KVStoreConstructor is a pointer to constructor of default KVStore
+var KVStoreConstructor KVFuncConstructor
+
+// KVStoreName have the name of kv store
+var KVStoreName string
+
+// SetDefault set the default kv store
+func SetDefault(name string, initPtr KVFuncConstructor) error {
+	KVStoreName = name
+	KVStoreConstructor = initPtr
+
+	return nil
+}
+
+// New initialize the default KV store.
+func New(config *KVConfig) (KVStore, error) {
+	if KVStoreConstructor != nil {
+		return KVStoreConstructor(config)
+	}
+
+	return nil, errors.New("No store backend configured...")
+}

--- a/lib/neosearch/store/registry.go
+++ b/lib/neosearch/store/registry.go
@@ -3,7 +3,7 @@ package store
 import "fmt"
 
 // KVStoreConstructor is the register function that every store backend need to implement.
-type KVStoreConstructor func(*KVConfig) (KVStore, error)
+type KVStoreConstructor func(KVConfig) (KVStore, error)
 
 type KVStoreRegistry map[string]KVStoreConstructor
 

--- a/lib/neosearch/store/registry.go
+++ b/lib/neosearch/store/registry.go
@@ -20,14 +20,3 @@ func RegisterKVStore(name string, constructor KVStoreConstructor) {
 func KVStoreConstructorByName(name string) KVStoreConstructor {
 	return stores[name]
 }
-
-/*
-// New initialize the default KV store.
-func New(config *KVConfig) (KVStore, error) {
-	if KVStoreConstructor != nil {
-		return KVStoreConstructor(config)
-	}
-
-	return nil, errors.New("No store backend configured...")
-}
-*/

--- a/lib/neosearch/store/registry.go
+++ b/lib/neosearch/store/registry.go
@@ -1,24 +1,27 @@
 package store
 
-import "errors"
+import "fmt"
 
-// KVFuncConstructor is the register function that every store backend need to implement.
-type KVFuncConstructor func(*KVConfig) (KVStore, error)
+// KVStoreConstructor is the register function that every store backend need to implement.
+type KVStoreConstructor func(*KVConfig) (KVStore, error)
 
-// KVStoreConstructor is a pointer to constructor of default KVStore
-var KVStoreConstructor KVFuncConstructor
+type KVStoreRegistry map[string]KVStoreConstructor
 
-// KVStoreName have the name of kv store
-var KVStoreName string
+var stores = make(KVStoreRegistry, 0)
 
-// SetDefault set the default kv store
-func SetDefault(name string, initPtr KVFuncConstructor) error {
-	KVStoreName = name
-	KVStoreConstructor = initPtr
-
-	return nil
+func RegisterKVStore(name string, constructor KVStoreConstructor) {
+	_, exists := stores[name]
+	if exists {
+		panic(fmt.Errorf("attempted to register duplicate store named '%s'", name))
+	}
+	stores[name] = constructor
 }
 
+func KVStoreConstructorByName(name string) KVStoreConstructor {
+	return stores[name]
+}
+
+/*
 // New initialize the default KV store.
 func New(config *KVConfig) (KVStore, error) {
 	if KVStoreConstructor != nil {
@@ -27,3 +30,4 @@ func New(config *KVConfig) (KVStore, error) {
 
 	return nil, errors.New("No store backend configured...")
 }
+*/

--- a/lib/neosearch/store/store.go
+++ b/lib/neosearch/store/store.go
@@ -1,7 +1,5 @@
 package store
 
-import "errors"
-
 // KVReader is a reader safe for concurrent reads.
 type KVReader interface {
 	Get([]byte) ([]byte, error)
@@ -54,30 +52,4 @@ type KVConfig struct {
 	DataDir     string
 	EnableCache bool
 	CacheSize   int
-}
-
-// KVFuncConstructor is the register function that every store backend need to implement.
-type KVFuncConstructor func(*KVConfig) (KVStore, error)
-
-// KVStoreConstructor is a pointer to constructor of default KVStore
-var KVStoreConstructor KVFuncConstructor
-
-// KVStoreName have the name of kv store
-var KVStoreName string
-
-// SetDefault set the default kv store
-func SetDefault(name string, initPtr KVFuncConstructor) error {
-	KVStoreName = name
-	KVStoreConstructor = initPtr
-
-	return nil
-}
-
-// New initialize the default KV store.
-func New(config *KVConfig) (KVStore, error) {
-	if KVStoreConstructor != nil {
-		return KVStoreConstructor(config)
-	}
-
-	return nil, errors.New("No store backend configured...")
 }

--- a/lib/neosearch/store/store.go
+++ b/lib/neosearch/store/store.go
@@ -47,9 +47,4 @@ type KVIterator interface {
 }
 
 // KVConfig stores the kv configurations
-type KVConfig struct {
-	Debug       bool
-	DataDir     string
-	EnableCache bool
-	CacheSize   int
-}
+type KVConfig map[string]interface{}

--- a/lib/neosearch/store/utils.go
+++ b/lib/neosearch/store/utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-func validateDatabaseName(name string) bool {
+func ValidateDatabaseName(name string) bool {
 	if len(name) < 3 {
 		return false
 	}

--- a/service/neosearch/config.yml
+++ b/service/neosearch/config.yml
@@ -6,13 +6,14 @@ dataDir: /data
 # Enables debug in every neosearch module
 debug: false
 
-# enable/disable cache support
-enableCache: true
-
-# CacheSize is the length of LRU cache used by the storage engine
-# Default is 1GB (1 << 30)
-cacheSize: 1073741824
-
 # maxIndicesOpen is the max number of indices maintained open by neosearch
 # for cached searchs
 maxIndicesOpen: 10
+
+store:
+    # enable/disable cache support
+    enableCache: true
+    # CacheSize is the length of LRU cache used by the storage engine
+    # Default is 1GB (1 << 30)
+    cacheSize: 1073741824
+

--- a/service/neosearch/main.go
+++ b/service/neosearch/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/store"
 	"github.com/NeowayLabs/neosearch/service/neosearch/server"
 	"github.com/jteeuwen/go-pkg-optarg"
 )
@@ -96,7 +97,7 @@ func main() {
 		log.Println("No configuration file supplied. Using defaults...")
 		cfg.Debug = false
 		cfg.DataDir = "/data"
-		cfg.EnableCache = true
+		cfg.KVConfig = store.KVConfig{"enableCache": true}
 	} else {
 		cfg, err = neosearch.ConfigFromFile(configOpt)
 


### PR DESCRIPTION
- Separated each KVStore in your own directory
- Added support for register more than one KVStore
- Setting leveldb as default storage
- Check-Lock-Check pattern a better aproach for singleton implementation
- Changed interface KVConfig to map[string]interface{} - support other specific store configuration
