### PR TITLE
Improvements in neosearch settings

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -53,8 +53,8 @@ func main() {
 		dataDirOpt, _ = os.Getwd()
 	}
 
-	ng := engine.New(engine.NGConfig{
-		KVCfg: store.KVConfig{
+	ng := engine.New(&engine.Config{
+		KVConfig: store.KVConfig{
 			"dataDir": dataDirOpt,
 			"debug":   debugOpt,
 		},

--- a/cmd/import/main.go
+++ b/cmd/import/main.go
@@ -13,8 +13,8 @@ import (
 	"launchpad.net/gommap"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/index"
-	"github.com/NeowayLabs/neosearch/lib/neosearch/store"
 	"github.com/jteeuwen/go-pkg-optarg"
 )
 
@@ -99,14 +99,10 @@ func main() {
 		}
 	}
 
-	cfg := neosearch.NewConfig()
+	cfg := config.NewConfig()
 
-	cfg.Option(neosearch.DataDir(dataDirOpt))
-	cfg.Option(neosearch.Debug(debugOpt))
-	cfg.Option(neosearch.KVConfig(store.KVConfig{
-		"enableCache": true,
-		"cacheSize":   (1 << 15),
-	}))
+	cfg.Option(config.DataDir(dataDirOpt))
+	cfg.Option(config.Debug(debugOpt))
 
 	neo := neosearch.New(cfg)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,10 +46,10 @@ import (
 )
 
 func main() {
-    ng := engine.New(engine.NGConfig{
-	    KVCfg: &store.KVConfig{
-		DataDir: "/tmp/",
-		Debug:   false,
+    ng := engine.New(&engine.Config{
+	    KVConfig: &store.KVConfig{
+		  DataDir: "/tmp/",
+		  Debug:   false,
 	    },
     })
 

--- a/lib/neosearch/engine/config.go
+++ b/lib/neosearch/engine/config.go
@@ -1,0 +1,48 @@
+package engine
+
+import (
+	"github.com/NeowayLabs/neosearch/lib/neosearch/store"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/store/goleveldb"
+)
+
+const (
+	// OpenCacheSize is the default value for the maximum number of
+	// open database files. This value can be override by
+	// Config.OpenCacheSize.
+	DefaultOpenCacheSize int = 100
+
+	// BatchSize is the default size of cached operations before
+	// a write batch occurs. You can override this value with
+	// Config.BatchSize.
+	DefaultBatchSize int = 5000
+
+	// DefaultKVStore set the default KVStore
+	DefaultKVStore string = goleveldb.KVName
+)
+
+// Config configure the Engine
+type Config struct {
+	// OpenCacheSize adjust the length of maximum number of
+	// open indices. This is a LRU cache, the least used
+	// database open will be closed when needed.
+	OpenCacheSize int `yaml:"openCacheSize"`
+
+	// BatchSize batch write size
+	BatchSize int `yaml:"batchSize"`
+
+	// KVStore configure the kvstore to be used
+	KVStore string `yaml:"kvstore"`
+
+	// KVStore specific options to kvstore
+	KVConfig store.KVConfig `yaml:"kvconfig"`
+}
+
+// New creates new Config
+func NewConfig() *Config {
+	return &Config{
+		DefaultOpenCacheSize,
+		DefaultBatchSize,
+		DefaultKVStore,
+		nil,
+	}
+}

--- a/lib/neosearch/engine/engine_test.go
+++ b/lib/neosearch/engine/engine_test.go
@@ -71,8 +71,8 @@ func cmpIterator(t *testing.T, itReturns []map[int64]string, ng *Engine, seek []
 // TestEngineIntegerKeyOrder verifies if the chosen storage engine is really
 // a LSM database ordered by key with ByteWise comparator.
 func TestEngineIntegerKeyOrder(t *testing.T) {
-	ng := New(NGConfig{
-		KVCfg: store.KVConfig{
+	ng := New(&Config{
+		KVConfig: store.KVConfig{
 			"dataDir": DataDirTmp,
 		},
 		OpenCacheSize: 1,

--- a/lib/neosearch/examples_test.go
+++ b/lib/neosearch/examples_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 )
 
 func OnErrorPanic(err error) {
@@ -20,9 +21,8 @@ func Example() {
 
 	OnErrorPanic(err)
 
-	cfg := neosearch.NewConfig()
-	cfg.Option(neosearch.DataDir(dataDir))
-	cfg.Option(neosearch.Debug(false))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDir))
 
 	neo := neosearch.New(cfg)
 	defer neo.Close()
@@ -56,9 +56,9 @@ func ExampleMatchPrefix() {
 
 	OnErrorPanic(err)
 
-	cfg := neosearch.NewConfig()
-	cfg.Option(neosearch.DataDir(dataDir))
-	cfg.Option(neosearch.Debug(false))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDir))
+	cfg.Option(config.Debug(false))
 
 	neo := neosearch.New(cfg)
 	defer neo.Close()

--- a/lib/neosearch/index/index_build_test.go
+++ b/lib/neosearch/index/index_build_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/engine"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/utils"
 )
@@ -22,10 +23,8 @@ func TestIndexBuildUintCommands(t *testing.T) {
 		cmd      engine.Command
 	)
 
-	cfg := Config{
-		Debug:   false,
-		DataDir: DataDirTmp,
-	}
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	err = os.MkdirAll(DataDirTmp, 0755)
 
@@ -82,10 +81,8 @@ func TestIndexBuildBoolCommands(t *testing.T) {
 		cmd      engine.Command
 	)
 
-	cfg := Config{
-		Debug:   false,
-		DataDir: DataDirTmp,
-	}
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	err = os.MkdirAll(DataDirTmp, 0755)
 

--- a/lib/neosearch/index/index_metadata_test.go
+++ b/lib/neosearch/index/index_metadata_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/engine"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/utils"
 )
@@ -24,10 +25,8 @@ func TestSimpleIndexWithMetadata(t *testing.T) {
 		}
 	)
 
-	cfg := Config{
-		Debug:   false,
-		DataDir: DataDirTmp,
-	}
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	err = os.MkdirAll(DataDirTmp, 0755)
 
@@ -233,10 +232,8 @@ func TestDateIndex(t *testing.T) {
 		}
 	)
 
-	cfg := Config{
-		Debug:   true,
-		DataDir: DataDirTmp,
-	}
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	err = os.MkdirAll(DataDirTmp, 0755)
 

--- a/lib/neosearch/index/index_object_test.go
+++ b/lib/neosearch/index/index_object_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/engine"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/utils"
 )
@@ -30,10 +31,8 @@ func TestBuildAddObjectDocument(t *testing.T) {
 		index *Index
 	)
 
-	cfg := Config{
-		Debug:   false,
-		DataDir: DataDirTmp,
-	}
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	err = os.MkdirAll(DataDirTmp, 0755)
 

--- a/lib/neosearch/index/index_test.go
+++ b/lib/neosearch/index/index_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/engine"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/utils"
 )
@@ -28,10 +29,8 @@ func createIndex(indexName string, t *testing.T) (*Index, error) {
 		indexDir = DataDirTmp + "/" + indexName
 	)
 
-	cfg := Config{
-		Debug:   false,
-		DataDir: DataDirTmp,
-	}
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	err = os.MkdirAll(DataDirTmp, 0755)
 

--- a/lib/neosearch/neosearch_test.go
+++ b/lib/neosearch/neosearch_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/index"
 )
 
@@ -23,9 +24,8 @@ func init() {
 }
 
 func TestCreateIndex(t *testing.T) {
-	cfg := NewConfig()
-	cfg.Option(DataDir(DataDirTmp))
-	cfg.Option(Debug(false))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	neo := New(cfg)
 
@@ -84,9 +84,8 @@ func TestOpenIndexCache(t *testing.T) {
 		indx *index.Index
 	)
 
-	cfg := NewConfig()
-	cfg.Option(DataDir(DataDirTmp))
-	cfg.Option(Debug(false))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	neo := New(cfg)
 
@@ -142,9 +141,8 @@ cleanup:
 }
 
 func TestDeleteIndex(t *testing.T) {
-	cfg := NewConfig()
-	cfg.Option(DataDir(DataDirTmp))
-	cfg.Option(Debug(false))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	neo := New(cfg)
 
@@ -176,10 +174,8 @@ func TestAddDocument(t *testing.T) {
 		total      uint64
 	)
 
-	cfg := NewConfig()
-
-	cfg.Option(DataDir(DataDirTmp))
-	cfg.Option(Debug(false))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	neo := New(cfg)
 
@@ -282,10 +278,8 @@ func BenchmarkAddDocuments(b *testing.B) {
 
 	indexDir := dataDirTmp + "/" + indexName
 
-	cfg := NewConfig()
-
-	cfg.Option(DataDir(dataDirTmp))
-	cfg.Option(Debug(false))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDirTmp))
 
 	neo := New(cfg)
 
@@ -367,10 +361,8 @@ func TestAddDocumentWithObject(t *testing.T) {
     }
 }`
 
-	cfg := NewConfig()
-
-	cfg.Option(DataDir(DataDirTmp))
-	cfg.Option(Debug(false))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	neo := New(cfg)
 
@@ -564,10 +556,8 @@ func TestComplexDocument(t *testing.T) {
     ]
 }`
 
-	cfg := NewConfig()
-
-	cfg.Option(DataDir(DataDirTmp))
-	cfg.Option(Debug(false))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	neo := New(cfg)
 
@@ -654,9 +644,8 @@ func TestPrefixMatch(t *testing.T) {
 		indexDir  = DataDirTmp + "/" + indexName
 	)
 
-	cfg := NewConfig()
-	cfg.Option(DataDir(DataDirTmp))
-	cfg.Option(Debug(false))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	neo := New(cfg)
 
@@ -747,9 +736,8 @@ func TestBatchAdd(t *testing.T) {
 		indexDir  = DataDirTmp + "/" + indexName
 	)
 
-	cfg := NewConfig()
-	cfg.Option(DataDir(DataDirTmp))
-	cfg.Option(Debug(false))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(DataDirTmp))
 
 	neo := New(cfg)
 

--- a/lib/neosearch/store/goleveldb/store.go
+++ b/lib/neosearch/store/goleveldb/store.go
@@ -65,42 +65,42 @@ func (lvdb *LVDB) setup(config store.KVConfig) {
 		lvdb.dataDir = "/tmp"
 	}
 
-	ro, ok := config["read_only"].(bool)
+	ro, ok := config["readOnly"].(bool)
 	if ok {
 		opts.ReadOnly = ro
 	}
 
-	cim, ok := config["create_if_missing"].(bool)
+	cim, ok := config["errorIfMissing"].(bool)
 	if ok {
-		opts.ErrorIfMissing = !cim
+		opts.ErrorIfMissing = cim
 	}
 
-	eie, ok := config["error_if_exists"].(bool)
+	eie, ok := config["errorIfExist"].(bool)
 	if ok {
 		opts.ErrorIfExist = eie
 	}
 
-	wbs, ok := config["write_buffer_size"].(float64)
+	wbs, ok := config["writeBuffer"].(float64)
 	if ok {
 		opts.WriteBuffer = int(wbs)
 	}
 
-	bs, ok := config["block_size"].(float64)
+	bs, ok := config["wlockSize"].(float64)
 	if ok {
 		opts.BlockSize = int(bs)
 	}
 
-	bri, ok := config["block_restart_interval"].(float64)
+	bri, ok := config["blockRestartInterval"].(float64)
 	if ok {
 		opts.BlockRestartInterval = int(bri)
 	}
 
-	lcc, ok := config["lru_cache_capacity"].(float64)
+	lcc, ok := config["blockCacheCapacity"].(float64)
 	if ok {
 		opts.BlockCacheCapacity = int(lcc)
 	}
 
-	bfbpk, ok := config["bloom_filter_bits_per_key"].(float64)
+	bfbpk, ok := config["bloomFilterBitsPerKey"].(float64)
 	if ok {
 		bf := filter.NewBloomFilter(int(bfbpk))
 		opts.Filter = bf

--- a/service/neosearch/config.yml
+++ b/service/neosearch/config.yml
@@ -8,12 +8,39 @@ debug: false
 
 # maxIndicesOpen is the max number of indices maintained open by neosearch
 # for cached searchs
-maxIndicesOpen: 10
+maxIndicesOpen: 50
 
-store:
+engine:
+    # openCacheSize is the value for the maximum number of
+    # open database files.
+    openCacheSize: 100
+    # batchSize is the size of cached operations before
+    # a write batch occurs.
+    batchSize: 5000
+    # kvstore set the kvstore to be used
+    kvstore: goleveldb
+    # kvstoreConfig set specific options for the kvstore
+    kvconfig: *KVSTORE_CONFIG
+
+goleveldb: &KVSTORE_CONFIG
+    # WriteBuffer defines maximum size of a 'memdb' before flushed to
+    # 'sorted table'. 'memdb' is an in-memory DB backed by an on-disk
+    # unsorted journal.
+    writeBuffer: 4194304
+    # BlockSize is the minimum uncompressed size in bytes of each 'sorted table'
+    # block.
+    blockSize: 4096
+    # BlockRestartInterval is the number of keys between restart points for
+    # delta encoding of keys.
+    blockRestartInterval: 16
+    # BlockCacheCapacity defines the capacity of the 'sorted table' block caching.
+    # Default is 4MB
+    blockCacheCapacity: 1073741824
+    bloomFilterBitsPerKey: 16
+
+leveldb:
     # enable/disable cache support
     enableCache: true
     # CacheSize is the length of LRU cache used by the storage engine
-    # Default is 1GB (1 << 30)
+    # Default is 1GB
     cacheSize: 1073741824
-

--- a/service/neosearch/home/home_test.go
+++ b/service/neosearch/home/home_test.go
@@ -1,16 +1,28 @@
 package home
 
 import (
+	"io/ioutil"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/julienschmidt/httprouter"
 )
 
+var dataDirTmp string
+
+func init() {
+	var err error
+	dataDirTmp, err = ioutil.TempDir("/tmp", "neosearch-service-home-")
+	if err != nil {
+		panic(err)
+	}
+}
+
 func getHomeHandler() *HomeHandler {
-	cfg := neosearch.NewConfig()
-	cfg.Option(neosearch.DataDir("/tmp/"))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDirTmp))
 	ns := neosearch.New(cfg)
 	return NewHomeHandler(ns)
 }

--- a/service/neosearch/index/add_test.go
+++ b/service/neosearch/index/add_test.go
@@ -11,12 +11,13 @@ import (
 	"testing"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/julienschmidt/httprouter"
 )
 
 func getAddDocHandler() *AddHandler {
-	cfg := neosearch.NewConfig()
-	cfg.Option(neosearch.DataDir("/tmp/"))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDirTmp))
 	ns := neosearch.New(cfg)
 
 	handler := NewAddHandler(ns)

--- a/service/neosearch/index/create_test.go
+++ b/service/neosearch/index/create_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 )
 
 func getCreateHandler() *CreateIndexHandler {
-	cfg := neosearch.NewConfig()
-	cfg.Option(neosearch.DataDir("/tmp/"))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDirTmp))
 	ns := neosearch.New(cfg)
 
 	handler := NewCreateHandler(ns)

--- a/service/neosearch/index/delete_test.go
+++ b/service/neosearch/index/delete_test.go
@@ -10,12 +10,13 @@ import (
 	"testing"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/julienschmidt/httprouter"
 )
 
 func getDeleteHandler() *DeleteIndexHandler {
-	cfg := neosearch.NewConfig()
-	cfg.Option(neosearch.DataDir("/tmp/"))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDirTmp))
 	ns := neosearch.New(cfg)
 
 	handler := NewDeleteHandler(ns)

--- a/service/neosearch/index/get_analyze_test.go
+++ b/service/neosearch/index/get_analyze_test.go
@@ -11,12 +11,13 @@ import (
 	"testing"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/julienschmidt/httprouter"
 )
 
 func getAnalyzeGetHandler() *GetAnalyseHandler {
-	cfg := neosearch.NewConfig()
-	cfg.Option(neosearch.DataDir("/tmp/"))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDirTmp))
 	ns := neosearch.New(cfg)
 
 	handler := NewGetAnalyzeHandler(ns)

--- a/service/neosearch/index/get_test.go
+++ b/service/neosearch/index/get_test.go
@@ -10,12 +10,13 @@ import (
 	"testing"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/julienschmidt/httprouter"
 )
 
 func getGetHandler() *GetHandler {
-	cfg := neosearch.NewConfig()
-	cfg.Option(neosearch.DataDir("/tmp/"))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDirTmp))
 	ns := neosearch.New(cfg)
 
 	handler := NewGetHandler(ns)

--- a/service/neosearch/index/index_test.go
+++ b/service/neosearch/index/index_test.go
@@ -2,15 +2,27 @@ package index
 
 import (
 	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/NeowayLabs/neosearch/lib/neosearch/index"
 )
 
+var dataDirTmp string
+
+func init() {
+	var err error
+	dataDirTmp, err = ioutil.TempDir("/tmp", "neosearch-service-index-")
+	if err != nil {
+		panic(err)
+	}
+}
+
 func getIndexHandler() *IndexHandler {
-	cfg := neosearch.NewConfig()
-	cfg.Option(neosearch.DataDir("/tmp/"))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDirTmp))
 	ns := neosearch.New(cfg)
 
 	handler := New(ns)

--- a/service/neosearch/index/search_test.go
+++ b/service/neosearch/index/search_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 	"github.com/julienschmidt/httprouter"
 )
 
 func getSearchHandler() *SearchHandler {
-	cfg := neosearch.NewConfig()
-	cfg.Option(neosearch.DataDir("/tmp/"))
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDirTmp))
 	ns := neosearch.New(cfg)
 
 	handler := NewSearchHandler(ns)

--- a/service/neosearch/server/server_test.go
+++ b/service/neosearch/server/server_test.go
@@ -10,12 +10,23 @@ import (
 	"testing"
 
 	"github.com/NeowayLabs/neosearch/lib/neosearch"
+	"github.com/NeowayLabs/neosearch/lib/neosearch/config"
 )
 
+var dataDirTmp string
+
+func init() {
+	var err error
+	dataDirTmp, err = ioutil.TempDir("/tmp", "neosearch-service-server-")
+	if err != nil {
+		panic(err)
+	}
+}
+
 func getServer(t *testing.T) (*httptest.Server, *neosearch.NeoSearch, error) {
-	config := neosearch.NewConfig()
-	config.Option(neosearch.DataDir("/tmp/"))
-	search := neosearch.New(config)
+	cfg := config.NewConfig()
+	cfg.Option(config.DataDir(dataDirTmp))
+	search := neosearch.New(cfg)
 	serverConfig := ServerConfig{
 		Host: "0.0.0.0",
 		Port: 9500,
@@ -199,7 +210,7 @@ func TestRESTIndexInfo(t *testing.T) {
 
 	errMsg := resObj["error"]
 
-	if errMsg.(string) != "Index 'test' not found in directory '/tmp'." {
+	if errMsg.(string) != "Index 'test' not found in directory '"+dataDirTmp+"'." {
 		t.Error("Wrong error message")
 	}
 }


### PR DESCRIPTION
This closes #44 - Option to configure the store default and more improvements in the settings

Neosearch:
    - Option to configurate the max number of indices open

Engine:
    - Option to configurate the maximum number of open database files
    - Option to configurate the size of cached operations before a write batch occurs
    - Option to configurate the kvstore to be used

Store:
    - Specific options for the kvstore
